### PR TITLE
Added SaveGame after call to MainSettings

### DIFF
--- a/src/start_menu/start_menu.cpp
+++ b/src/start_menu/start_menu.cpp
@@ -3,6 +3,7 @@
 #include "continue_game/continue_game.h"
 #include "main_settings/main_settings.h"
 #include "start_game/start_game.h"
+#include "save_and_load_game/save_game/save_game.h"
 
 #include <iostream>
 #include <string>
@@ -46,6 +47,7 @@ void StartMenu(MainCharacter& main_character)
 				case 3:
 					{
 						MainSettings();
+						SaveGame(main_character);
 						break;
 					}
 				case 4:
@@ -73,6 +75,7 @@ void StartMenu(MainCharacter& main_character)
 				case 2:
 					{
 						MainSettings();
+						SaveGame(main_character);
 						break;
 					}
 				case 3:


### PR DESCRIPTION
It is necessary to save the game state after a setting has been altered, so that the LoadGame getting called from ContinueGame does not overwrite the newly-selected value with that of the save file.

closes #76 