### PR TITLE
Deprecated codecvt from project

### DIFF
--- a/src/start_menu/main_settings/change_text_font.cpp
+++ b/src/start_menu/main_settings/change_text_font.cpp
@@ -6,42 +6,9 @@
 void ChangeTextFont()
 {
 	std::cout << "Pick text font.\n" << std::endl;
-	std::vector<std::string> const text_font_options{"Consolas",
-		"DejaVu Sans Mono",
-		"Liberation Mono",
-		"Lucida Console",
-		"MS Gothic"};
 
-	int text_font_choice = utils::GetUserConstrainedChoice(text_font_options);
-
-	switch (text_font_choice)
-	{
-		case 1:
-			{
-				utils::g_text_face_name = "Consolas";
-				break;
-			}
-		case 2:
-			{
-				utils::g_text_face_name = "DejaVu Sans Mono";
-				break;
-			}
-		case 3:
-			{
-				utils::g_text_face_name = "Liberation Mono";
-				break;
-			}
-		case 4:
-			{
-				utils::g_text_face_name = "Lucida Console";
-				break;
-			}
-		case 5:
-			{
-				utils::g_text_face_name = "MS Gothic";
-				break;
-			}
-	}
+	int text_font_choice = utils::GetUserConstrainedChoice(utils::AVAILABLE_TEXT_FACE_NAMES);
+	utils::g_text_face_name = utils::AVAILABLE_TEXT_FACE_NAMES[text_font_choice - 1];
 
 	utils::CustomizeText();
 }

--- a/src/utils/customize_text/customize_text.cpp
+++ b/src/utils/customize_text/customize_text.cpp
@@ -1,19 +1,31 @@
 #include "customize_text.h"
 
-#include <codecvt>
-#include <cwchar>
-#include <locale>
+#include <iostream>
+#include <unordered_map>
 #include <windows.h>
 
 int utils::g_text_size = 16;
 utils::FontWeightValues utils::g_text_weight = utils::FontWeightValues::Normal;
-std::string utils::g_text_face_name = "Consolas";
+std::string utils::g_text_face_name = utils::AVAILABLE_TEXT_FACE_NAMES[0];
 
-static std::wstring to_wstring(const std::string& stringToConvert)
+std::unordered_map<std::string, std::wstring> const string_to_wstring_face_name_map{
+	{utils::AVAILABLE_TEXT_FACE_NAMES[0], L"Consolas"},
+	{utils::AVAILABLE_TEXT_FACE_NAMES[1], L"DejaVu Sans Mono"},
+	{utils::AVAILABLE_TEXT_FACE_NAMES[2], L"Liberation Mono"},
+	{utils::AVAILABLE_TEXT_FACE_NAMES[3], L"Lucida Console"},
+	{utils::AVAILABLE_TEXT_FACE_NAMES[4], L"MS Gothic"}};
+
+static std::wstring to_wstring(const std::string& textFaceNameToConvert)
 {
-	std::wstring const wideString =
-		std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(stringToConvert);
-	return wideString;
+	const auto it = string_to_wstring_face_name_map.find(textFaceNameToConvert);
+	if (it != string_to_wstring_face_name_map.end())
+	{
+		return it->second;
+	}
+
+	std::cerr << "The font face " << it->first
+			  << " could not be converted to a known wide-string font face.\n";
+	return L"Consolas";
 }
 
 void utils::CustomizeText()

--- a/src/utils/customize_text/customize_text.h
+++ b/src/utils/customize_text/customize_text.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace utils
 {
@@ -19,6 +20,12 @@ extern int g_text_size;
 extern FontWeightValues g_text_weight;
 // A string for the font typeface used.
 extern std::string g_text_face_name;
+
+std::vector<std::string> const AVAILABLE_TEXT_FACE_NAMES{"Consolas",
+	"DejaVu Sans Mono",
+	"Liberation Mono",
+	"Lucida Console",
+	"MS Gothic"};
 
 /**
  * @brief A function that changes the basic aesthetics of the text.


### PR DESCRIPTION
The use of codecvt for the conversion of the text font name into a wstring was problematic. The facet hass been deprecated since C++17, and its use required a Visual C++ Redistributable to be installed on the target machine. Refactored code to avoid it.

A useful tool that helped identify the dependencies of this project can be found here:
https://github.com/lucasg/Dependencies